### PR TITLE
Fix saved poster display sizing issue by changing classes and tags in innerHTML

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -201,10 +201,10 @@ function displaySavedPosters() {
   posterGrid.innerHTML = "";
   for(var i = 0; i < savedPosters.length; i++) {
     posterGrid.innerHTML +=
-    `<article class="poster">
+    `<article class="mini-poster">
       <img class="poster-img" src="${savedPosters[i].imageURL}" alt="nothin' to see here">
-      <h1 class="poster-title">${savedPosters[i].title}</h1>
-      <h3 class="poster-quote">${savedPosters[i].quote}</h3>
+      <h2 class="poster-title">${savedPosters[i].title}</h2>
+      <h4 class="poster-quote">${savedPosters[i].quote}</h4>
      </article>`;
   }
 }


### PR DESCRIPTION


## Is this a fix or a feature?

fix

## What is the change?

change innerHTML

## What does it fix?

style issue

## Where should the reviewer start?

lines 204, 206, and 207


## How should this be tested?

open index.html, save 3 posters, then view saved